### PR TITLE
headless-browser: Add flag to dump screenshots of failing ref-tests

### DIFF
--- a/Ladybird/CMakeLists.txt
+++ b/Ladybird/CMakeLists.txt
@@ -258,7 +258,7 @@ include(CTest)
 if (BUILD_TESTING)
     add_test(
         NAME LibWeb
-        COMMAND ${CMAKE_CURRENT_BINARY_DIR}/../bin/headless-browser --resources "${SERENITY_SOURCE_DIR}/Base/res" --run-tests ${SERENITY_SOURCE_DIR}/Tests/LibWeb
+        COMMAND ${CMAKE_CURRENT_BINARY_DIR}/../bin/headless-browser --resources "${SERENITY_SOURCE_DIR}/Base/res" --run-tests ${SERENITY_SOURCE_DIR}/Tests/LibWeb --dump-failed-ref-tests
     )
     add_test(
         NAME WPT


### PR DESCRIPTION
Do we do CI? Let's find out!